### PR TITLE
Fix for https://github.com/bem-site/gorshochek/issues/37 : extension added, borschik.freeze used instead of sha1

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,8 +67,7 @@
     "lodash": "^4.x",
     "marked": "^0.3.5",
     "q": "^2.x",
-    "rsync-slim": "^1.1.0",
-    "sha1": "^1.1.1"
+    "rsync-slim": "^1.1.0"
   },
   "devDependencies": {
     "chai": "^3.4.1",

--- a/src/tasks/override/process-doc-images.js
+++ b/src/tasks/override/process-doc-images.js
@@ -5,7 +5,7 @@ const Path = require('path');
 const Url = require('url');
 const _ = require('lodash');
 const Q = require('q');
-const sha1 = require('sha1');
+const freeze = require('borschik/lib/freeze');
 const cheerio = require('cheerio');
 const baseUtil = require('../../util');
 const util = require('./util');
@@ -66,7 +66,9 @@ module.exports = (model, options) => {
             return Q(null);
         }
 
-        const filePath = Path.join(options.imageFolder, sha1(imageUrl));
+        // FIXME: freeze file content, not imageUrl !!!
+        const freezeFileName = freeze.fixBase64(freeze.sha1Base64(imageUrl)) + Path.extname(imageUrl);
+        const filePath = Path.join(options.imageFolder, freezeFileName);
 
         debug(`load image from: ${imageUrl} to: ${filePath}`);
         return baseUtil.isFileExists(Path.join(baseUtil.getCacheFolder(), filePath))

--- a/test/src/tasks/override/process-doc-images.test.js
+++ b/test/src/tasks/override/process-doc-images.test.js
@@ -54,7 +54,7 @@ describe('tasks/override/process-doc-images', () => {
         });
 
         it('should load images given by absolute http urls in html', () => {
-            const staticPath = '/static/004be58d47d1c4a523e00e086e3832bb2abc56b3';
+            const staticPath = '/static/AEvljUfRxKUj4A4Ibjgyuyq8VrM.png';
             const imageUrl = 'http://some-host/some-image.png';
 
             baseUtil.readFileFromCache.returns(Q(`<img src="${imageUrl}">`));
@@ -68,7 +68,7 @@ describe('tasks/override/process-doc-images', () => {
         });
 
         it('should load images given by relative urls in html', () => {
-            const staticPath = '/static/004be58d47d1c4a523e00e086e3832bb2abc56b3';
+            const staticPath = '/static/AEvljUfRxKUj4A4Ibjgyuyq8VrM.png';
             const imageUrl = '../some-image.png';
 
             baseUtil.readFileFromCache.returns(Q(`<img src="${imageUrl}">`));
@@ -84,7 +84,7 @@ describe('tasks/override/process-doc-images', () => {
         });
 
         it('should load images given by relative urls for github source', () => {
-            const staticPath = '/static/95170956e857f816d18d4c73be0449ae7a53c939';
+            const staticPath = '/static/lRcJVuhX-BbRjUxzvgRJrnpTyTk.png';
             const imageUrl = '../some-image.png';
 
             baseUtil.readFileFromCache.returns(Q(`<img src="${imageUrl}">`));
@@ -101,7 +101,7 @@ describe('tasks/override/process-doc-images', () => {
         });
 
         it('should not load image file if it already exists in cache', function() {
-            const staticPath = '/static/004be58d47d1c4a523e00e086e3832bb2abc56b3';
+            const staticPath = '/static/AEvljUfRxKUj4A4Ibjgyuyq8VrM.png';
             const imageUrl = 'http://some-host/some-image.png';
 
             baseUtil.readFileFromCache.returns(Q(`<img src="${imageUrl}">`));


### PR DESCRIPTION
Fix for https://github.com/bem-site/gorshochek/issues/37:
1) extension added
2) borschik.freeze used instead of sha1

There is bug in current (and previous) implementation: sha1 must be evaluated from image content, not image url.